### PR TITLE
Provide I2S definitions for Autonomo

### DIFF
--- a/variants/sodaq_autonomo/variant.h
+++ b/variants/sodaq_autonomo/variant.h
@@ -235,6 +235,17 @@ static const uint8_t DAC0     = PIN_A0; // or (35u) implications for cores/ardui
 #define PIN_USB_DM          (47ul)
 #define PIN_USB_DP          (48ul)
 
+/*
+ * I2S Interfaces
+ */
+#define I2S_INTERFACES_COUNT 1
+
+#define I2S_DEVICE          0
+#define I2S_CLOCK_GENERATOR 3
+#define PIN_I2S_SD          (14u)
+#define PIN_I2S_SCK         (1u)
+#define PIN_I2S_FS          (2u)
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Dear SODAQ team,

as suggested by @janvl1234 and @GabrielNotman, we added I2S definitions for the SODAQ Autonomo board. Thanks to Jan, Gabriel and Clemens for sorting things out.

With kind regards,
the people of Hiveeyes.

----

References:
- http://forum.sodaq.com/t/arduino-i2s-library-is-no-t-w-working-on-the-autonomo/948
- https://community.hiveeyes.org/t/make-i2s-microphone-work-on-sodaq-autonomo/470
